### PR TITLE
Fix problem with 2FA auth

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ class WithingsGCBridge:
             email = secrets["garmin"]["email"]
             password = secrets["garmin"]["password"]
             try:
-                garmin = garminconnect.Garmin(email, password)
+                garmin = garminconnect.Garmin(email, password, prompt_mfa=lambda: input("Enter MFA code: "))
                 garmin.login()
                 garmin.garth.dump(self.tokenstore)
 


### PR DESCRIPTION
Instead of passing None, put a real lambda and get 2FA value sent to email/cellphone

python-garminconnect code:
```
class Garmin:
    """Class for fetching data from Garmin Connect."""

    def __init__(
        self,
        email: str | None = None,
        password: str | None = None,
        is_cn: bool = False,
        prompt_mfa: Callable[[], str] | None = None,
        return_on_mfa: bool = False,
```

Garth docs:
```
garth.login(email, password, prompt_mfa=lambda: input("Enter MFA code: "))
```